### PR TITLE
Resolve User Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ First, you'll need to get an export of your Slack workspace. Instructions for th
 
 With that export in hand, you'll need to copy all of the files within it under `public/data/`. This will be where the backend of this app expects to see all of the data regarding your workspace.
 
+To clarify; if your slack export is in a folder named `slack-export`, then you'll want to put the files _under_ it into `public/data`, not the folder itself.
+
 Finally, run the development server:
 
 ```bash

--- a/components/messageList.tsx
+++ b/components/messageList.tsx
@@ -1,34 +1,6 @@
 import { Message } from "models/message";
 import { User } from "models/user";
-
-function sortedMessages(messages: Message[]) {
-  return messages.sort((a: Message, b: Message) => Number(a.ts) - Number(b.ts));
-}
-
-function resolveIDs(messages: Message[], users: User[]) {
-  let userMap: { [id: string]: User } = {};
-  for (const user of users) {
-    userMap[user.id] = user;
-  }
-  for (let message of messages) {
-    if (message.user_profile === undefined) {
-      let user = userMap[message.user];
-      message.user_profile = {
-        real_name: user.profile.real_name,
-        display_name: user.profile.display_name,
-      };
-    }
-    if (message.bot_id !== undefined) {
-      message.text = "We are unable to display bot messages at this time.";
-      message.user_profile.real_name =
-        "[BOT] " + message.user_profile.real_name;
-    } else {
-      message.text = message.text.replace(/<@(U\w+)>/gi, (match, p1) => {
-        return "@" + userMap[p1].real_name;
-      });
-    }
-  }
-}
+import { resolveIDs, sortedMessages } from "utils/slack";
 
 export default (props: { messages: Message[]; users: User[] }) => {
   resolveIDs(props.messages, props.users);

--- a/components/messageList.tsx
+++ b/components/messageList.tsx
@@ -5,7 +5,33 @@ function sortedMessages(messages: Message[]) {
   return messages.sort((a: Message, b: Message) => Number(a.ts) - Number(b.ts));
 }
 
-export default (props: { messages: Message[] }) => {
+function resolveIDs(messages: Message[], users: User[]) {
+  let userMap: { [id: string]: User } = {};
+  for (const user of users) {
+    userMap[user.id] = user;
+  }
+  for (let message of messages) {
+    if (message.user_profile === undefined) {
+      let user = userMap[message.user];
+      message.user_profile = {
+        real_name: user.profile.real_name,
+        display_name: user.profile.display_name,
+      };
+    }
+    if (message.bot_id !== undefined) {
+      message.text = "We are unable to display bot messages at this time.";
+      message.user_profile.real_name =
+        "[BOT] " + message.user_profile.real_name;
+    } else {
+      message.text = message.text.replace(/<@(U\w+)>/gi, (match, p1) => {
+        return "@" + userMap[p1].real_name;
+      });
+    }
+  }
+}
+
+export default (props: { messages: Message[]; users: User[] }) => {
+  resolveIDs(props.messages, props.users);
   return (
     <ul>
       {sortedMessages(props.messages).map((message: Message) => {

--- a/models/message.ts
+++ b/models/message.ts
@@ -9,15 +9,15 @@ export interface Message {
   user_team?: string;
   source_team?: string;
   user_profile?: {
-    avatar_hash: string;
-    image_72: string;
-    first_name: string;
+    avatar_hash?: string;
+    image_72?: string;
+    first_name?: string;
     real_name: string;
     display_name: string;
-    team: string;
-    name: string;
-    is_restricted: boolean;
-    is_ultra_restricted: boolean;
+    team?: string;
+    name?: string;
+    is_restricted?: boolean;
+    is_ultra_restricted?: boolean;
   };
   blocks?: {
     type: string;

--- a/pages/channels/[channelName].tsx
+++ b/pages/channels/[channelName].tsx
@@ -9,7 +9,7 @@ export default function () {
   const router = useRouter();
   const { channelName } = router.query;
   const { data } = useSWR(channelName ? `/api/channels/${channelName}` : null);
-  if (channelName) {
+  if (data) {
     console.log(data);
     const messages = data?.messages;
     const channel = data?.channel;
@@ -19,7 +19,7 @@ export default function () {
         <>
           <h1>#{channelName}</h1>
           {channel && <MemberTable channel={channel} users={users} />}
-          {messages && <MessageList messages={messages} />}
+          {messages && <MessageList messages={messages} users={users} />}
         </>
       </Layout>
     );

--- a/pages/channels/[channelName].tsx
+++ b/pages/channels/[channelName].tsx
@@ -1,7 +1,6 @@
 import Layout from "components/layout";
 import { useRouter } from "next/router";
 import useSWR from "swr";
-import { Message } from "models/message";
 import MessageList from "components/messageList";
 import MemberTable from "components/memberTable";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,3 @@
-import Head from "next/head";
 import useSWR from "swr";
 import ChannelList from "components/channelList";
 import Layout from "components/layout";

--- a/utils/slack.ts
+++ b/utils/slack.ts
@@ -1,0 +1,39 @@
+import { Message } from "models/message";
+import { User } from "models/user";
+
+const slackIDRegex = /<@(U\w+)>/gi;
+
+export function sortedMessages(messages: Message[]) {
+  return messages.sort((a: Message, b: Message) => Number(a.ts) - Number(b.ts));
+}
+
+export function resolveMessageIDs(
+  message: Message,
+  userMap: { [id: string]: User }
+) {
+  if (message.user_profile === undefined) {
+    let user = userMap[message.user];
+    message.user_profile = {
+      real_name: user?.profile.real_name || "Unknown (likely a bot)",
+      display_name: user?.profile.display_name,
+    };
+  }
+  if (message.bot_id !== undefined) {
+    message.text = "We are unable to display bot messages at this time.";
+    message.user_profile.real_name = "[BOT] " + message.user_profile.real_name;
+  } else {
+    message.text = message.text.replace(slackIDRegex, (match, p1) => {
+      return "@" + userMap[p1].real_name;
+    });
+  }
+}
+
+export function resolveIDs(messages: Message[], users: User[]) {
+  let userMap: { [id: string]: User } = {};
+  for (const user of users) {
+    userMap[user.id] = user;
+  }
+  for (let message of messages) {
+    resolveMessageIDs(message, userMap);
+  }
+}


### PR DESCRIPTION
In this PR, we resolve #1.

We utilize the existing information about users, channels, and messages to have all of the data be figured out client-side. These utilities have been placed into a utils folder so that the functionality may be reused throughout the application.

It should be noted that certain bots/slack integrations are not correctly recognized by this PR and those have been noted as "Unknown (most likely a bot)" in their name.

The regex used to extract slack user ids can be played with [here](https://regex101.com/r/7oMFkf/1).