### PR TITLE
Workspace-wide statistics

### DIFF
--- a/components/memberTable.tsx
+++ b/components/memberTable.tsx
@@ -9,7 +9,7 @@ import CenterDiv from "components/centerDiv";
 import MessageRatioChart from "components/charts/messageRatioChart";
 
 export default (props: {
-  channel: Channel;
+  channel: { name: string; members: string[] };
   users: User[];
   messages: Message[];
 }) => {

--- a/pages/api/channels/[channelName].ts
+++ b/pages/api/channels/[channelName].ts
@@ -4,7 +4,7 @@ import { Message } from "models/message";
 import { Channel } from "models/channel";
 import { User } from "models/user";
 
-async function getMessagesForChannel(channelName: string | string[]) {
+export async function getMessagesForChannel(channelName: string | string[]) {
   let messages: Message[] = [];
 
   let file_list = await fs.promises.readdir(
@@ -34,7 +34,7 @@ async function getChannelInfo(channelName: string | string[]) {
   return channel;
 }
 
-async function getUsers() {
+export async function getUsers() {
   let users = JSON.parse(
     await fs.promises.readFile("public/data/users.json", "utf-8")
   );

--- a/pages/api/channels/index.ts
+++ b/pages/api/channels/index.ts
@@ -1,5 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import fs from "fs";
+import { Channel } from "models/channel";
+import { getMessagesForChannel, getUsers } from "./[channelName]";
+import { Message } from "models/message";
+import { User } from "models/user";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   let channels_string = "";
@@ -17,6 +21,23 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     return;
   }
   let channels = JSON.parse(channels_string);
+  let messages: Message[] = [];
+  let users: User[];
+  try {
+    users = await getUsers();
+    for (const channel of channels) {
+      const messagesForChannel = await getMessagesForChannel(channel.name);
+      messages = messages.concat(messagesForChannel);
+    }
+  } catch (err) {
+    res.statusCode = 500;
+    res.json({
+      error: err.message,
+      diagonosis:
+        "something went wrong when retrieving messages or users for the workspace",
+    });
+    return;
+  }
   res.statusCode = 200;
-  res.json({ channels });
+  res.json({ channels, users, messages });
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,16 +1,27 @@
 import useSWR from "swr";
 import ChannelList from "components/channelList";
 import Layout from "components/layout";
+import MemberTable from "components/memberTable";
+import KeywordSearch from "components/keywordSearch";
 
 export default function Home() {
-  const { data: channelsWrapper, mutate } = useSWR("/api/channels");
-
-  if (channelsWrapper) {
+  const { data, mutate } = useSWR("/api/channels");
+  debugger;
+  if (data) {
+    const channels = data?.channels;
+    const messages = data?.messages;
+    const users = data?.users;
+    const workspace = {
+      name: "Workspace",
+      members: users,
+    };
     return (
       <Layout>
         <>
           <h1>A list of slack channels should appear here:</h1>
-          <ChannelList channels={channelsWrapper.channels} />
+          <MemberTable channel={workspace} users={users} messages={messages} />
+          <KeywordSearch users={users} messages={messages} />
+          <ChannelList channels={channels} />
         </>
       </Layout>
     );


### PR DESCRIPTION
This PR resolves #7.

I do this by bringing the accordion elements from the channel-specific view to the index page. This also required changing the backend to all of the workspace data in the API call made by the index page, but performance still seems to be within acceptable ranges at this point.