### PR TITLE
Add conversation comparison chart

### DIFF
--- a/components/charts/conversationChart.tsx
+++ b/components/charts/conversationChart.tsx
@@ -1,0 +1,13 @@
+import { BarChart, Tooltip, XAxis, YAxis, Bar, Legend } from "recharts";
+import { NamedData } from "utils/plotting";
+
+export default (props: { data: NamedData[] }) => {
+  return (
+    <BarChart width={800} height={500} data={props.data}>
+      <Tooltip />
+      <XAxis dataKey="displayName" />
+      <YAxis />
+      <Bar dataKey="value" />
+    </BarChart>
+  );
+};

--- a/components/charts/messageRatioChart.tsx
+++ b/components/charts/messageRatioChart.tsx
@@ -1,11 +1,11 @@
 import { PieChart, Pie, Legend, Tooltip, PieLabelRenderProps } from "recharts";
-import { PieData } from "utils/plotting";
+import { SimpleData } from "utils/plotting";
 
 const nameAndCountLabel = (entry: PieLabelRenderProps) => {
   return [entry.name, entry.value].join(" | ");
 };
 
-export default (props: { messageRatioData: PieData[] }) => {
+export default (props: { messageRatioData: SimpleData[] }) => {
   return (
     <PieChart width={700} height={600}>
       <Pie

--- a/components/conversationComparisons.tsx
+++ b/components/conversationComparisons.tsx
@@ -1,0 +1,45 @@
+import Accordion from "react-bootstrap/Accordion";
+import Card from "react-bootstrap/Card";
+import AccordionToggle from "react-bootstrap/AccordionToggle";
+import Button from "react-bootstrap/Button";
+import AccordionCollapse from "react-bootstrap/AccordionCollapse";
+import ConversationChart from "components/charts/conversationChart";
+import { Message } from "models/message";
+import { User } from "models/user";
+import { userMessagePairCounts } from "utils/plotting";
+import CenterDiv from "./centerDiv";
+
+export default (props: { messages: Message[]; users: User[] }) => {
+  const messages = props?.messages;
+  const users = props?.users;
+  const data = userMessagePairCounts(props.users, props.messages);
+  return (
+    <Accordion>
+      <Card>
+        <Card.Header>
+          <AccordionToggle as={Button} variant="link" eventKey="0">
+            See conversation pairing statistics
+          </AccordionToggle>
+        </Card.Header>
+        <AccordionCollapse eventKey="0">
+          <Card.Body>
+            <CenterDiv>
+              <ConversationChart data={data} />
+            </CenterDiv>
+            The above abbreviations are expanded below:
+            <ul>
+              {data.map((data) => {
+                return (
+                  <li>
+                    {data.displayName} corresponds to {data.name} with{" "}
+                    {data.value} occurrences.
+                  </li>
+                );
+              })}
+            </ul>
+          </Card.Body>
+        </AccordionCollapse>
+      </Card>
+    </Accordion>
+  );
+};

--- a/components/messageList.tsx
+++ b/components/messageList.tsx
@@ -5,17 +5,20 @@ import { resolveIDs, sortedMessages } from "utils/slack";
 export default (props: { messages: Message[]; users: User[] }) => {
   resolveIDs(props.messages, props.users);
   return (
-    <ul>
-      {sortedMessages(props.messages).map((message: Message) => {
-        let day = new Date(Number(message.ts) * 1000);
-        return (
-          <li key={message.ts}>
-            ({day.toDateString()})
-            <b> {message.user_profile?.real_name || message.user}: </b>
-            {message.text}
-          </li>
-        );
-      })}
-    </ul>
+    <>
+      <p>There are {props.messages.length} messages.</p>
+      <ul>
+        {sortedMessages(props.messages).map((message: Message) => {
+          let day = new Date(Number(message.ts) * 1000);
+          return (
+            <li key={message.ts}>
+              ({day.toDateString()})
+              <b> {message.user_profile?.real_name || message.user}: </b>
+              {message.text}
+            </li>
+          );
+        })}
+      </ul>
+    </>
   );
 };

--- a/pages/channels/[channelName].tsx
+++ b/pages/channels/[channelName].tsx
@@ -4,6 +4,7 @@ import useSWR from "swr";
 import MessageList from "components/messageList";
 import MemberTable from "components/memberTable";
 import KeywordSearch from "components/keywordSearch";
+import ConversationComparisons from "components/conversationComparisons";
 
 export default function () {
   const router = useRouter();
@@ -19,6 +20,7 @@ export default function () {
           <h1>#{channelName}</h1>
           <MemberTable channel={channel} users={users} messages={messages} />
           <KeywordSearch messages={messages} users={users} />
+          <ConversationComparisons messages={messages} users={users} />
           <MessageList messages={messages} users={users} />
         </>
       </Layout>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,6 @@ import KeywordSearch from "components/keywordSearch";
 
 export default function Home() {
   const { data, mutate } = useSWR("/api/channels");
-  debugger;
   if (data) {
     const channels = data?.channels;
     const messages = data?.messages;


### PR DESCRIPTION
This PR resolves #9.

It turns out that adding support for a chord chart would take quite a bit in order to add the required d3 code, so this PR serves as a compromise. Instead of a chord chart, I added a bar chart like the one below instead:

![image](https://user-images.githubusercontent.com/15284810/84551534-cf504a80-acc2-11ea-9a18-f1859a78ede0.png)

We essentially count the senders of every pair of consecutive messages. An example series of messages such as:

- Person A: Hello!
- Person B: Hi!
- Person B: How are you doing?
- Person A: Good.

This would be counted up as follows:

- A-B: 2
- B-B: 1

If the need really does arise for a full-on chord chart we can address that need in another PR, but I feel this does a good enough job of starting the conversation.